### PR TITLE
Fixing cancel volatility method.

### DIFF
--- a/volatile_dictionary/volatile_dict.py
+++ b/volatile_dictionary/volatile_dict.py
@@ -51,6 +51,7 @@ class VolatileDictionary(dict):
         if not self.is_set_volatile(key):
             raise NonvolatileTypeError(key)
         self._scheduler.remove_job(self._evaporation_jobs[key])
+        del self._evaporation_jobs[key]
 
     def get_set_lifetime(self, key):
         if not self.is_set_volatile(key):


### PR DESCRIPTION
Cancel was canceling the evaporation job but not removing its id from the evaporation_jobs dict.